### PR TITLE
Switch Windows builds to Travis CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,0 @@
-build_script:
-- cmd: >-
-    git clone https://github.com/KhronosGroup/Vulkan-Docs &&
-    "C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat" &&
-    cl /c /W4 /WX /IVulkan-Docs/include volk.c
-
-test: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
-language: cpp
-os: linux
-compiler:
-  - clang
-  - gcc
+language: sh
+os:
+  - linux
+  - osx
+  - windows
+
+before_script:
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then PATH=$PATH:/c/Program\ Files/CMake/bin; fi
 
 script:
   - git clone https://github.com/KhronosGroup/Vulkan-Docs
-  - cc -c volk.c -Wall -Wextra -Werror -IVulkan-Docs/include # check Vulkan 1.1 build
+  - export VULKAN_SDK=./Vulkan-Docs
+  - cmake .
+  - cmake --build . # check Vulkan 1.1 build
   - git -C Vulkan-Docs checkout ab08f0951ef1ad9b84db93f971e113c1d9d55609 # last 1.0 rev
-  - cc -c volk.c -Wall -Wextra -Werror -IVulkan-Docs/src # check Vulkan 1.0 build
+  - mv Vulkan-Docs/src Vulkan-Docs/include # CMakeLists.txt assume /include location for headers...
+  - cmake --build . # check Vulkan 1.0 build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+project(volk)
+cmake_minimum_required(VERSION 3.0)
+
+add_library(volk STATIC volk.c)
+
+if(MSVC)
+  target_compile_options(volk PRIVATE /W4 /WX)
+else()
+  target_compile_options(volk PRIVATE -Wall -Wextra -Werror)
+endif()
+
+if(DEFINED ENV{VULKAN_SDK})
+	target_include_directories(volk PUBLIC "$ENV{VULKAN_SDK}/include")
+endif()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🐺 volk [![Build Status](https://travis-ci.org/zeux/volk.svg?branch=master)](https://travis-ci.org/zeux/volk) [![Build status](https://ci.appveyor.com/api/projects/status/m2aulhj6fj44kxk0/branch/master?svg=true)](https://ci.appveyor.com/project/zeux/volk)
+# 🐺 volk [![Build Status](https://travis-ci.org/zeux/volk.svg?branch=master)](https://travis-ci.org/zeux/volk) (https://ci.appveyor.com/project/zeux/volk)
 
 ## Purpose
 


### PR DESCRIPTION
This PR removes AppVeyor build and adds Travis CI windows build instead. To make things simpler we also add a CMakeLists.txt that can be used to build the library for testing.