### PR TITLE
fix for `error: undefined reference to dlopen` on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ if(MSVC)
   target_compile_options(volk PRIVATE /W4 /WX)
 else()
   target_compile_options(volk PRIVATE -Wall -Wextra -Werror)
+  target_link_libraries(volk PRIVATE dl)
 endif()
 
 if(DEFINED ENV{VULKAN_SDK})


### PR DESCRIPTION
See #17 