### PR TITLE
Remove dependencies on windows.h

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -3,6 +3,7 @@
 
 #ifdef _WIN32
 	typedef const char* LPCSTR;
+	typedef struct HINSTANCE__* HINSTANCE;
 	typedef HINSTANCE HMODULE;
 	#ifdef _WIN64
 		typedef __int64 (__stdcall* FARPROC)();

--- a/volk.c
+++ b/volk.c
@@ -2,13 +2,24 @@
 #include "volk.h"
 
 #ifdef _WIN32
-#	include <windows.h>
+	typedef const char* LPCSTR;
+	typedef HINSTANCE HMODULE;
+	#ifdef _WIN64
+		typedef __int64 (__stdcall* FARPROC)();
+	#else
+		typedef int (__stdcall* FARPROC)();
+	#endif
 #else
 #	include <dlfcn.h>
 #endif
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+#ifdef _WIN32
+__declspec(dllimport) HMODULE __stdcall LoadLibraryA(LPCSTR);
+__declspec(dllimport) FARPROC __stdcall GetProcAddress(HMODULE, LPCSTR);
 #endif
 
 static void volkGenLoadLoader(void* context, PFN_vkVoidFunction (*load)(void*, const char*));

--- a/volk.h
+++ b/volk.h
@@ -33,7 +33,7 @@
 		typedef unsigned long DWORD;
 		typedef const wchar_t* LPCWSTR;
 		typedef void* HANDLE;
-		typedef struct HINSTANCE__ *HINSTANCE;
+		typedef struct HINSTANCE__* HINSTANCE;
 		typedef struct HWND__* HWND;
 		typedef struct HMONITOR__* HMONITOR;
 		typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;

--- a/volk.h
+++ b/volk.h
@@ -22,7 +22,26 @@
 #endif
 
 #ifndef VULKAN_H_
-#	include <vulkan/vulkan.h>
+#	ifdef VK_USE_PLATFORM_WIN32_KHR
+#		include <vulkan/vk_platform.h>
+#		include <vulkan/vulkan_core.h>
+
+		/* When VK_USE_PLATFORM_WIN32_KHR is defined, instead of including vulkan.h directly, we include individual parts of the SDK
+		 * This is necessary to avoid including <windows.h> which is very heavy - it takes 200ms to parse without WIN32_LEAN_AND_MEAN
+		 * and 100ms to parse with it. vulkan_win32.h only needs a few symbols that are easy to redefine ourselves.
+		 */
+		typedef unsigned long DWORD;
+		typedef const wchar_t* LPCWSTR;
+		typedef void* HANDLE;
+		typedef struct HINSTANCE__ *HINSTANCE;
+		typedef struct HWND__* HWND;
+		typedef struct HMONITOR__* HMONITOR;
+		typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
+
+#		include <vulkan/vulkan_win32.h>
+#	else
+#		include <vulkan/vulkan.h>
+#	endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This change makes sure that including volk.h doesn't pull in windows.h
with it - windows.h is a *very* heavy dependency, and it's not that
necessary since we only need a few symbols from it in the header.

As a result, including volk.h is now 200-100ms faster on a very fast CPU
with a hot FS cache depending on whether WIN32_LEAN_AND_MEAN is defined
or not.

Fixes #21.