### PR TITLE
Clarify function prototypes

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -6,9 +6,9 @@
 	typedef struct HINSTANCE__* HINSTANCE;
 	typedef HINSTANCE HMODULE;
 	#ifdef _WIN64
-		typedef __int64 (__stdcall* FARPROC)();
+		typedef __int64 (__stdcall* FARPROC)(void);
 	#else
-		typedef int (__stdcall* FARPROC)();
+		typedef int (__stdcall* FARPROC)(void);
 	#endif
 #else
 #	include <dlfcn.h>


### PR DESCRIPTION
If compiling w/ -Wstrict-prototypes the compiler complains about these decls.
Add "void" to clarify that these are func protos with no params.