### PR TITLE
Added support for CMake's config-based installation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,21 @@
-project(volk)
 cmake_minimum_required(VERSION 3.0)
 
-add_library(volk STATIC volk.c)
+# Set the project version to the vulkan header version.
+file(STRINGS volk.h matched_line REGEX "#define[ \t]+VOLK_HEADER_VERSION" LIMIT_INPUT 1000)
+string(REGEX MATCH "([0-9\\.]+)$" parsed_version ${matched_line})
+if(NOT parsed_version)
+  message(FATAL_ERROR "Failed to parse VOLK_HEADER_VERSION!")
+endif()
+
+project(volk VERSION ${parsed_version} LANGUAGES C)
+
+find_package(Vulkan REQUIRED)
+
+add_library(volk STATIC volk.c volk.h)
+target_include_directories(volk PUBLIC 
+  $<INSTALL_INTERFACE:include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
 
 if(MSVC)
   target_compile_options(volk PRIVATE /W4 /WX)
@@ -10,6 +24,53 @@ else()
   target_link_libraries(volk PRIVATE dl)
 endif()
 
-if(DEFINED ENV{VULKAN_SDK})
+find_package(Vulkan)
+if(TARGET Vulkan::Vulkan) 
+  target_link_libraries(volk PUBLIC Vulkan::Vulkan)
+elseif(DEFINED ENV{VULKAN_SDK})
 	target_include_directories(volk PUBLIC "$ENV{VULKAN_SDK}/include")
 endif()
+
+# Installation
+
+include(GNUInstallDirs)
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/volk)
+
+# Install header
+install(FILES volk.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# Install library target and add it and any dependencies to export set.
+install(
+    TARGETS volk
+    EXPORT volk-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# Actually write exported config w/ imported targets
+install(EXPORT volk-targets
+    FILE volkTargets.cmake
+    NAMESPACE volk::
+    DESTINATION ${INSTALL_CONFIGDIR}
+)
+
+# Create a ConfigVersion.cmake file:
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/volkConfigVersion.cmake
+    COMPATIBILITY AnyNewerVersion
+)
+
+# Configure config file
+configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/volkConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/volkConfig.cmake
+    INSTALL_DESTINATION ${INSTALL_CONFIGDIR}
+)
+
+# Install the fully generated config and configVersion files
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/volkConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/volkConfigVersion.cmake
+    DESTINATION ${INSTALL_CONFIGDIR}
+)

--- a/volkConfig.cmake.in
+++ b/volkConfig.cmake.in
@@ -1,0 +1,13 @@
+get_filename_component(volk_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+if(NOT TARGET volk::volk)
+  include("${volk_CMAKE_DIR}/volkTargets.cmake")
+endif()
+set(volk_LIBRARIES volk::volk)
+
+find_package(Vulkan)
+if(TARGET Vulkan::Vulkan) 
+  add_dependencies(volk::volk Vulkan::Vulkan)
+elseif(DEFINED ENV{VULKAN_SDK})
+  target_include_directories(volk PUBLIC "$ENV{VULKAN_SDK}/include")
+endif()


### PR DESCRIPTION
This pull request adds support for modern CMake installation. Volk will build exactly like before if not running install, but can now also install proper config and target files for volk as an imported target. This allows building against volk with

find_package(volk CONFIG REQUIRED)
target_link_libraries(myTarget PRIVATE volk::volk)

Installed packages require a version number which volk itself lacks. I chose to use the Vulkan version the generated files are based upon by parsing volk.h at build time. 
The behaviour of pulling in Vulkan transitively if found is preserved, for both the direct compilation and the imported target linking. I also have an integration of volk with vcpkg ready, for which this, if not strictly necessary, would be very helpful.
Should you find that CMakeLists.txt looks scary now, I agree, CMake requires *a lot* of boilerplate for this. I'd be happy to add more explaining comments if needed. This is mostly based upon https://github.com/pabloariasal/modern-cmake-sample.