### PR TITLE
Correct MacOS library name

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -50,7 +50,7 @@ VkResult volkInitialize(void)
 #elif defined(__APPLE__)
 	void* module = dlopen("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
 	if (!module)
-		module = dlopen("libvulkan.dylib.1", RTLD_NOW | RTLD_LOCAL);
+		module = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
 	if (!module)
 		module = dlopen("libMoltenVK.dylib", RTLD_NOW | RTLD_LOCAL);
 	if (!module)


### PR DESCRIPTION
The SDK ships with libvulkan.1.1.x.dylib, libvulkan.1.dylib, and libvulkan.dylib.