### PR TITLE
Avoid re-loading same global entrypoints

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -23,6 +23,9 @@ __declspec(dllimport) HMODULE __stdcall LoadLibraryA(LPCSTR);
 __declspec(dllimport) FARPROC __stdcall GetProcAddress(HMODULE, LPCSTR);
 #endif
 
+static VkInstance loadedInstance = VK_NULL_HANDLE;
+static VkDevice loadedDevice = VK_NULL_HANDLE;
+
 static void volkGenLoadLoader(void* context, PFN_vkVoidFunction (*load)(void*, const char*));
 static void volkGenLoadInstance(void* context, PFN_vkVoidFunction (*load)(void*, const char*));
 static void volkGenLoadDevice(void* context, PFN_vkVoidFunction (*load)(void*, const char*));
@@ -95,13 +98,20 @@ uint32_t volkGetInstanceVersion(void)
 
 void volkLoadInstance(VkInstance instance)
 {
-	volkGenLoadInstance(instance, vkGetInstanceProcAddrStub);
-	volkGenLoadDevice(instance, vkGetInstanceProcAddrStub);
+	if (loadedInstance != instance)
+	{
+		volkGenLoadInstance(instance, vkGetInstanceProcAddrStub);
+		volkGenLoadDevice(instance, vkGetInstanceProcAddrStub);
+	}
+	loadedInstance = instance;
 }
 
 void volkLoadDevice(VkDevice device)
 {
-	volkGenLoadDevice(device, vkGetDeviceProcAddrStub);
+	if (loadedDevice != device)
+		volkGenLoadDevice(device, vkGetDeviceProcAddrStub);
+
+	loadedDevice = device;
 }
 
 void volkLoadDeviceTable(struct VolkDeviceTable* table, VkDevice device)

--- a/volk.h
+++ b/volk.h
@@ -77,11 +77,13 @@ uint32_t volkGetInstanceVersion(void);
 
 /**
  * Load global function pointers using application-created VkInstance; call this function after creating the Vulkan instance.
+ * If global function pointers are already currently loaded for this instance, no action is taken.
  */
 void volkLoadInstance(VkInstance instance);
 
 /**
  * Load global function pointers using application-created VkDevice; call this function after creating the Vulkan device.
+ * If global function pointers are already currently loaded for this device, no action is taken.
  *
  * Note: this is not suitable for applications that want to use multiple VkDevice objects concurrently.
  */


### PR DESCRIPTION
Add static VkInstance and VkDevice vars to track the last
instance and device for which global entrypoints have been loaded.

When calling volkLoadInstance() or volkLoadDevice(), avoid
re-loading entrypoints for the same instance or device respectively.

This is useful for ANGLE where we iterate testing over different
single VkDevice objects on the same physical box. We can re-call the
volkLoad* functions and only incur the updates when needed.