### PR TITLE
Add clang-format comments

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -1,4 +1,5 @@
 /* This file is part of volk library; see volk.h for version/license details */
+/* clang-format off */
 #include "volk.h"
 
 #ifdef _WIN32
@@ -1677,3 +1678,4 @@ PFN_vkAcquireNextImage2KHR vkAcquireNextImage2KHR;
 #ifdef __cplusplus
 }
 #endif
+/* clang-format on */

--- a/volk.h
+++ b/volk.h
@@ -6,6 +6,7 @@
  *
  * This library is distributed under the MIT License. See notice at the end of this file.
  */
+/* clang-format off */
 #ifndef VOLK_H_
 #define VOLK_H_
 
@@ -1093,3 +1094,4 @@ extern PFN_vkAcquireNextImage2KHR vkAcquireNextImage2KHR;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
 */
+/* clang-format on */


### PR DESCRIPTION
Disable clang-formatting for volk source files.
This will simplify integration with other projects, such as ANGLE,
where clang-formatting may significantly change the code and make
comparisons more difficult.