### PR TITLE
Add query interface for loaded instance/device

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -23,6 +23,9 @@ __declspec(dllimport) HMODULE __stdcall LoadLibraryA(LPCSTR);
 __declspec(dllimport) FARPROC __stdcall GetProcAddress(HMODULE, LPCSTR);
 #endif
 
+static VkInstance loadedInstance = VK_NULL_HANDLE;
+static VkDevice loadedDevice = VK_NULL_HANDLE;
+
 static void volkGenLoadLoader(void* context, PFN_vkVoidFunction (*load)(void*, const char*));
 static void volkGenLoadInstance(void* context, PFN_vkVoidFunction (*load)(void*, const char*));
 static void volkGenLoadDevice(void* context, PFN_vkVoidFunction (*load)(void*, const char*));
@@ -95,12 +98,14 @@ uint32_t volkGetInstanceVersion(void)
 
 void volkLoadInstance(VkInstance instance)
 {
+	loadedInstance = instance;
 	volkGenLoadInstance(instance, vkGetInstanceProcAddrStub);
 	volkGenLoadDevice(instance, vkGetInstanceProcAddrStub);
 }
 
 void volkLoadDevice(VkDevice device)
 {
+	loadedDevice = device;
 	volkGenLoadDevice(device, vkGetDeviceProcAddrStub);
 }
 

--- a/volk.h
+++ b/volk.h
@@ -88,6 +88,18 @@ void volkLoadInstance(VkInstance instance);
 void volkLoadDevice(VkDevice device);
 
 /**
+ * Return last VkInstance for which global function pointers have been loaded via volkLoadInstance(),
+ * or VK_NULL_HANDLE if volkLoadInstance() has not been called.
+ */
+VkInstance volkGetLoadedInstance();
+
+/**
+ * Return last VkDevice for which global function pointers have been loaded via volkLoadDevice(),
+ * or VK_NULL_HANDLE if volkLoadDevice() has not been called.
+ */
+VkDevice volkGetLoadedDevice();
+
+/**
  * Load function pointers using application-created VkDevice into a table.
  * Application should use function pointers from that table instead of using global function pointers.
  */


### PR DESCRIPTION
Add static VkInstance and VkDevice vars to track the last
instance and device for which global entrypoints have been loaded.

When calling volkLoadInstance() or volkLoadDevice(), update
tracking instance and device vars.

Provide volkGetLoadedInstance() and volkGetLoadedDevice() functions
to query the instance/device respectively for which global function
pointers have most recently been loaded.

This is useful for ANGLE where we iterate testing over different
single VkDevice objects on the same physical box. We can re-call the
volkLoad* functions and only incur the updates when needed.