### PR TITLE
Give precedence to libvulkan.so.1 over libvulkan.so

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -62,9 +62,9 @@ VkResult volkInitialize(void)
 
 	vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)dlsym(module, "vkGetInstanceProcAddr");
 #else
-	void* module = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
+	void* module = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
 	if (!module)
-		module = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
+		module = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
 	if (!module)
 		return VK_ERROR_INITIALIZATION_FAILED;
 


### PR DESCRIPTION
The correct dlopen behaviour is to load libraries by SONAME. The current
behaviour can cause different versions of libvulkan to be loaded at
runtime. And having multiple loaders in the same app can have undesired
side-effects.

We keep the libvulkan.so fallback for cases Android platforms where only
that name may be available.