### PR TITLE
Fix a regression with NVX_image_view_handle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,30 @@ jobs:
     runs-on: ${{matrix.os}}-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
       with:
         repository: KhronosGroup/Vulkan-Headers
+        ref: master
         path: Vulkan-Headers
-    - name: build
+    - name: move sdk
       shell: bash
       run: |
-        mv Vulkan-Headers ~/Vulkan-Headers
+        mv ../Vulkan-Headers ~/Vulkan-Headers
+    - name: build master
+      shell: bash
+      run: |
         export VULKAN_SDK=~/Vulkan-Headers
+        git -C ~/Vulkan-Headers checkout master
+        test/run_tests.sh
+    - name: build 1.1.101
+      shell: bash
+      run: |
+        export VULKAN_SDK=~/Vulkan-Headers
+        git -C ~/Vulkan-Headers checkout sdk-1.1.101
+        test/run_tests.sh
+    - name: build 1.2.131
+      shell: bash
+      run: |
+        export VULKAN_SDK=~/Vulkan-Headers
+        git -C ~/Vulkan-Headers checkout sdk-1.2.131
         test/run_tests.sh

--- a/volk.h
+++ b/volk.h
@@ -51,6 +51,11 @@
 #	endif
 #endif
 
+/* Disable VK_NVX_image_view_handle because SDK 140 introduced a change that can't be used with prior versions */
+#if VK_HEADER_VERSION < 140
+#	undef VK_NVX_image_view_handle
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This extension can't be used on SDK <140 because of a new function
introduced retroactively.

Also adds CI setup to catch issues like this in the future.

Fixes #48.
