### PR TITLE
Add namespace alias for libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 # Interface library
 
 add_library(volk_headers INTERFACE)
+add_library(volk::volk_headers ALIAS volk_headers)
 target_include_directories(volk_headers INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
   $<INSTALL_INTERFACE:include>


### PR DESCRIPTION
Good day,

For case when added as header only, using cmake_using_subdir_headers
We can now use both : volk::volk_headers and volk_headers
target_link_libraries( foo PRIVATE volk::volk_headers)

Best regards