### PR TITLE
Fix: Only run action on thursdays

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,7 +2,7 @@ name: update
 
 on:
   schedule:
-    - cron: '0 9 * * *'
+    - cron: '0 18 * * THU'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
As you can see by looking at the [amount of actions](https://github.com/zeux/volk/actions) being run, it's entirely wasteful for the runner to run every day. Instead, only run the Thursdays in the evening (the latest spec update I found was 3pm). Also delivers most spec updates faster as we don't have to wait until Friday 9am for updates to be pushed. Should a spec update occur later, a manual trigger can still be done.

The 1.3.216 changelog reads:
> Change log for June 2, 2022 Vulkan 1.3.216 spec update:
>
> * Update release number to 216 for this update.
> * Note: most spec updates will occur on Thursdays going forward, not
    Tuesdays.
