### PR TITLE
sdk: support the Vulkan SDK build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,18 @@ endif()
 
 if(VOLK_PULL_IN_VULKAN)
   # If CMake has the FindVulkan module and it works, use it.
-  # Otherwise try the environment variable.
   find_package(Vulkan QUIET)
-  if(TARGET Vulkan::Vulkan)
+
+  # Try an explicit CMake variable first, then any Vulkan targets
+  # discovered by FindVulkan.cmake, then the $VULKAN_SDK environment
+  # variable if nothing else works.
+  if(VULKAN_HEADERS_INSTALL_DIR)
+    message(" Vulkan as path")
+    if(TARGET volk)
+      target_include_directories(volk PUBLIC "${VULKAN_HEADERS_INSTALL_DIR}/include")
+    endif()
+    target_include_directories(volk_headers INTERFACE "${VULKAN_HEADERS_INSTALL_DIR}/include")
+  elseif(TARGET Vulkan::Vulkan)
     message(" Vulkan as target")
     if(TARGET volk)
       target_link_libraries(volk PUBLIC Vulkan::Vulkan)
@@ -75,7 +84,7 @@ if(VOLK_PULL_IN_VULKAN)
     endif()
     target_link_libraries(volk_headers INTERFACE Vulkan::Headers)
   elseif(DEFINED ENV{VULKAN_SDK})
-    message(" Vulkan as path")
+    message(" Vulkan as VULKAN_SDK path")
     if(TARGET volk)
       target_include_directories(volk PUBLIC "$ENV{VULKAN_SDK}/include")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ endif()
 if(NOT DEFINED VOLK_HEADERS_ONLY)
   option(VOLK_HEADERS_ONLY "Add interface library only" OFF)
 endif()
+if(NOT DEFINED VULKAN_HEADERS_INSTALL_DIR)
+  option(VULKAN_HEADERS_INSTALL_DIR "Where to get the Vulkan headers" "")
+endif()
 
 # -----------------------------------------------------
 # Static library


### PR DESCRIPTION
The Vulkan SDK build process needs to be able to pass a CMake variable in to the Volk build indicating where the Vulkan-Headers install build resides.  Otherwise, Volk could end up building with an older version of the SDK that happens to be installed on the build system (as our CI systems have various different SDK/loader combinations installed, for test purposes).

This change causes Volk to respect a VULKAN_HEADERS_INSTALL_DIR CMake variable, if defined.  The variable must be checked before the presence of a Vulkan SDK is checked, to ensure that a random SDK installed on the system doesn't interfere with the build.