### PR TITLE
Fix conflict between FARPROC definition and minwindef.h

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -6,7 +6,9 @@
 	typedef const char* LPCSTR;
 	typedef struct HINSTANCE__* HINSTANCE;
 	typedef HINSTANCE HMODULE;
-	#ifdef _WIN64
+	#if defined(_MINWINDEF_)
+		/* minwindef.h defines FARPROC, and attempting to redefine it may conflict with -Wstrict-prototypes */
+	#elif defined(_WIN64)
 		typedef __int64 (__stdcall* FARPROC)(void);
 	#else
 		typedef int (__stdcall* FARPROC)(void);


### PR DESCRIPTION
minwindef.h defines FARPROC without (void) argument list, so if it is already included when volk.c is compiled via VOLK_IMPLEMENTATION, gcc will emit an error (MSVC handles this mismatch fine).

Unfortunately, simply removing (void) results in a warning with Wstrict-prototypes even when volk.c is compiled as standalone. We could disable the warning with a pragma but for now we could simply reuse FARPROC definition from minwindef.h if it's already included.

Fixes #140 