### PR TITLE
Implement volkFinalize function

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -24,10 +24,12 @@ extern "C" {
 #ifdef _WIN32
 __declspec(dllimport) HMODULE __stdcall LoadLibraryA(LPCSTR);
 __declspec(dllimport) FARPROC __stdcall GetProcAddress(HMODULE, LPCSTR);
+__declspec(dllimport) int __stdcall FreeLibrary(HMODULE);
 #endif
 
 static VkInstance loadedInstance = VK_NULL_HANDLE;
 static VkDevice loadedDevice = VK_NULL_HANDLE;
+static void* loadedModule = NULL;
 
 static void volkGenLoadLoader(void* context, PFN_vkVoidFunction (*load)(void*, const char*));
 static void volkGenLoadInstance(void* context, PFN_vkVoidFunction (*load)(void*, const char*));
@@ -42,6 +44,14 @@ static PFN_vkVoidFunction vkGetInstanceProcAddrStub(void* context, const char* n
 static PFN_vkVoidFunction vkGetDeviceProcAddrStub(void* context, const char* name)
 {
 	return vkGetDeviceProcAddr((VkDevice)context, name);
+}
+
+static PFN_vkVoidFunction nullProcAddrStub(void* context, const char* name)
+{
+	(void)context;
+	(void)name;
+
+	return NULL;
 }
 
 VkResult volkInitialize(void)
@@ -73,6 +83,7 @@ VkResult volkInitialize(void)
 	vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)dlsym(module, "vkGetInstanceProcAddr");
 #endif
 
+	loadedModule = module;
 	volkGenLoadLoader(NULL, vkGetInstanceProcAddrStub);
 
 	return VK_SUCCESS;
@@ -82,7 +93,28 @@ void volkInitializeCustom(PFN_vkGetInstanceProcAddr handler)
 {
 	vkGetInstanceProcAddr = handler;
 
+	loadedModule = NULL;
 	volkGenLoadLoader(NULL, vkGetInstanceProcAddrStub);
+}
+
+void volkFinalize(void)
+{
+	if (loadedModule)
+	{
+#if defined(_WIN32)
+		FreeLibrary((HMODULE)loadedModule);
+#else
+		dlclose(loadedModule);
+#endif
+	}
+
+	volkGenLoadLoader(NULL, nullProcAddrStub);
+	volkGenLoadInstance(NULL, nullProcAddrStub);
+	volkGenLoadDevice(NULL, nullProcAddrStub);
+
+	loadedInstance = VK_NULL_HANDLE;
+	loadedDevice = VK_NULL_HANDLE;
+	loadedModule = NULL;
 }
 
 uint32_t volkGetInstanceVersion(void)

--- a/volk.c
+++ b/volk.c
@@ -27,9 +27,9 @@ __declspec(dllimport) FARPROC __stdcall GetProcAddress(HMODULE, LPCSTR);
 __declspec(dllimport) int __stdcall FreeLibrary(HMODULE);
 #endif
 
+static void* loadedModule = NULL;
 static VkInstance loadedInstance = VK_NULL_HANDLE;
 static VkDevice loadedDevice = VK_NULL_HANDLE;
-static void* loadedModule = NULL;
 
 static void volkGenLoadLoader(void* context, PFN_vkVoidFunction (*load)(void*, const char*));
 static void volkGenLoadInstance(void* context, PFN_vkVoidFunction (*load)(void*, const char*));
@@ -112,9 +112,9 @@ void volkFinalize(void)
 	volkGenLoadInstance(NULL, nullProcAddrStub);
 	volkGenLoadDevice(NULL, nullProcAddrStub);
 
+	loadedModule = NULL;
 	loadedInstance = VK_NULL_HANDLE;
 	loadedDevice = VK_NULL_HANDLE;
-	loadedModule = NULL;
 }
 
 uint32_t volkGetInstanceVersion(void)

--- a/volk.c
+++ b/volk.c
@@ -108,6 +108,7 @@ void volkFinalize(void)
 #endif
 	}
 
+	vkGetInstanceProcAddr = NULL;
 	volkGenLoadLoader(NULL, nullProcAddrStub);
 	volkGenLoadInstance(NULL, nullProcAddrStub);
 	volkGenLoadDevice(NULL, nullProcAddrStub);

--- a/volk.h
+++ b/volk.h
@@ -82,6 +82,11 @@ VkResult volkInitialize(void);
 void volkInitializeCustom(PFN_vkGetInstanceProcAddr handler);
 
 /**
+ * Finalize library by unloading Vulkan loader and resetting global symbols to NULL.
+ */
+void volkFinalize(void);
+
+/**
  * Get Vulkan instance version supported by the Vulkan loader, or 0 if Vulkan isn't supported
  *
  * Returns 0 if volkInitialize wasn't called or failed.


### PR DESCRIPTION
This is normally not necessary to call if the instance survives until the application shutdown, but it might be useful in some cases where a clean and complete instance recreation is needed, or if the application wants to tear down the Vulkan instance and then create an OpenGL instance while making sure the Vulkan DLLs are unloaded.

Fixes #152.