### PR TITLE
Fall back to /usr/local/lib/libvulkan.dylib on macOS

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -68,6 +68,10 @@ VkResult volkInitialize(void)
 		module = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
 	if (!module)
 		module = dlopen("libMoltenVK.dylib", RTLD_NOW | RTLD_LOCAL);
+	// modern versions of macOS don't search /usr/local/lib automatically contrary to what man dlopen says
+	// Vulkan SDK uses this as the system-wide installation location, so we're going to fallback to this if all else fails
+	if (!module)
+		module = dlopen("/usr/local/lib/libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
 	if (!module)
 		return VK_ERROR_INITIALIZATION_FAILED;
 

--- a/volk.c
+++ b/volk.c
@@ -17,6 +17,10 @@
 #	include <dlfcn.h>
 #endif
 
+#ifdef __APPLE__
+#	include <stdlib.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -70,7 +74,7 @@ VkResult volkInitialize(void)
 		module = dlopen("libMoltenVK.dylib", RTLD_NOW | RTLD_LOCAL);
 	// modern versions of macOS don't search /usr/local/lib automatically contrary to what man dlopen says
 	// Vulkan SDK uses this as the system-wide installation location, so we're going to fallback to this if all else fails
-	if (!module)
+	if (!module && getenv("DYLD_FALLBACK_LIBRARY_PATH") == NULL)
 		module = dlopen("/usr/local/lib/libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
 	if (!module)
 		return VK_ERROR_INITIALIZATION_FAILED;


### PR DESCRIPTION
dlopen on macOS is supposed to automatically search /usr/local/lib per dlopen man page. This behavior is customizable via DYLD_LIBRARY_PATH and DYLD_FALLBACK_LIBRARY_PATH, but even if neither is explicitly set /usr/local/lib should be a search path. Unfortunately, this does not happen anymore on modern macOS systems, and this is precisely where Vulkan SDK installs dylib by default.

This used to "work" in CMake builds that accidentally linked in libvulkan.dylib statically, because the library was already loaded into the process, but fixing that exposed this issue.

So we need to manually fallback to /usr/local/lib path. See https://developer.apple.com/forums/thread/737920 - looks like this change is intentional, and manual pages are out of date.

Fixes #163.