### PR TITLE
apple: Add support for loader or moltenvk in a framework

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -72,6 +72,12 @@ VkResult volkInitialize(void)
 		module = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
 	if (!module)
 		module = dlopen("libMoltenVK.dylib", RTLD_NOW | RTLD_LOCAL);
+    // Add support for using Vulkan and MoltenVK in a Framework. App store rules for iOS
+    // strictly enforce no .dylib's. If they aren't found it just falls through
+    if (!module)
+        module = dlopen("vulkan.framework/vulkan", RTLD_NOW | RTLD_LOCAL);
+    if (!module)
+        module = dlopen("MoltenVK.framework/MoltenVK", RTLD_NOW | RTLD_LOCAL);
 	// modern versions of macOS don't search /usr/local/lib automatically contrary to what man dlopen says
 	// Vulkan SDK uses this as the system-wide installation location, so we're going to fallback to this if all else fails
 	if (!module && getenv("DYLD_FALLBACK_LIBRARY_PATH") == NULL)


### PR DESCRIPTION
This adds framework binaries to the search list for the Vulkan Loader or MoltenVK on Apple platforms. The next version of the Vulkan SDK will be shipping both of these as Frameworks only on iOS, as the iOS app store strictly enforces the "no naked .dylib" rule.