### PR TITLE
CMake: cache variables that shouldn't be booleans are option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ project(volk VERSION
 # CMake 3.12 changes the default behaviour of option() to leave local variables
 # unchanged if they exist (which we want), but we must work with older CMake versions.
 if(NOT DEFINED VOLK_STATIC_DEFINES)
-  option(VOLK_STATIC_DEFINES "Additional defines for building the volk static library, e.g. Vulkan platform defines" "")
+  set(VOLK_STATIC_DEFINES "" CACHE STRING "Additional defines for building the volk static library, e.g. Vulkan platform defines")
 endif()
 if(NOT DEFINED VOLK_PULL_IN_VULKAN)
   option(VOLK_PULL_IN_VULKAN "Vulkan as a transitive dependency" ON)
@@ -24,7 +24,7 @@ if(NOT DEFINED VOLK_HEADERS_ONLY)
   option(VOLK_HEADERS_ONLY "Add interface library only" OFF)
 endif()
 if(NOT DEFINED VULKAN_HEADERS_INSTALL_DIR)
-  option(VULKAN_HEADERS_INSTALL_DIR "Where to get the Vulkan headers" "")
+  set(VULKAN_HEADERS_INSTALL_DIR "" CACHE PATH "Where to get the Vulkan headers")
 endif()
 
 # -----------------------------------------------------


### PR DESCRIPTION
The `VOLK_STATIC_DEFINES` and `VULKAN_HEADERS_INSTALL_DIR` cache variables in `CMakeLists` don't seem to do anything if you generate the cache without setting them because they will be booleans. As far as I understand it, `option` is for booleans and has always been. This fix swaps these variables to other types.