### PR TITLE
Extend platform support for WSI without the need to include windowing API

### DIFF
--- a/volk.h
+++ b/volk.h
@@ -34,7 +34,7 @@
  * VK_USE_PLATFORM_XCB_KHR
  * VK_USE_PLATFORM_DIRECTFB_EXT
  * VK_USE_PLATFORM_XLIB_XRANDR_EXT
- * VK_USE_PLATFORM_SCI
+ * VK_USE_PLATFORM_GGP
  *
  * Nothing needs to be done for the following platforms as they don't depend on platform-specific headers:
  * VK_USE_PLATFORM_MACOS_MVK
@@ -47,117 +47,136 @@
 #ifndef VULKAN_H_
 #	ifdef VOLK_VULKAN_H_PATH
 #		include VOLK_VULKAN_H_PATH
-#	elif defined(VK_USE_PLATFORM_FUCHSIA)
-#		include <vulkan/vk_platform.h>
-#		include <vulkan/vulkan_core.h>
+#   else
+#       if defined(VK_USE_PLATFORM_FUCHSIA)
+#		    include <vulkan/vk_platform.h>
+#		    include <vulkan/vulkan_core.h>
 
-        // If someone knows what the include guard for <lib/zx/handle.h> is, please add a guard arround this
-#       include <stdint.h>
-        uint32_t zx_handle_t;
-
-#		include <vulkan/vulkan_xcb.h>
-
-#		ifdef VK_ENABLE_BETA_EXTENSIONS
-#			include <vulkan/vulkan_beta.h>
-#		endif
-#	elif defined(VK_USE_PLATFORM_WIN32_KHR)
-#		include <vulkan/vk_platform.h>
-#		include <vulkan/vulkan_core.h>
-#       if !defined(WINDOWS_H)
-		    typedef unsigned long DWORD;
-		    typedef const wchar_t* LPCWSTR;
-		    typedef void* HANDLE;
-		    typedef struct HINSTANCE__* HINSTANCE;
-		    typedef struct HWND__* HWND;
-		    typedef struct HMONITOR__* HMONITOR;
-		    typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
-#       endif
-
-#		include <vulkan/vulkan_win32.h>
-
-#		ifdef VK_ENABLE_BETA_EXTENSIONS
-#			include <vulkan/vulkan_beta.h>
-#		endif
-#	elif defined(VK_USE_PLATFORM_XLIB_KHR)
-#		include <vulkan/vk_platform.h>
-#		include <vulkan/vulkan_core.h>
-
-        // This is not 1:1 what Xlib uses, but it's close enough for most purposes.
-#       if !defined(X_H)
+            // If someone knows what the include guard for <lib/zx/handle.h> is, please add a guard arround this
 #           include <stdint.h>
-            typedef struct Display Display;
-            typedef uint32_t Window;
-            typedef uint32_t VisualID;
+            typedef uint32_t zx_handle_t;
+
+#		    include <vulkan/vulkan_fuchsia.h>
+
+#		    ifdef VK_ENABLE_BETA_EXTENSIONS
+#		    	include <vulkan/vulkan_beta.h>
+#		    endif
 #       endif
+#	    if defined(VK_USE_PLATFORM_WIN32_KHR)
+#	    	include <vulkan/vk_platform.h>
+#	    	include <vulkan/vulkan_core.h>
+#           if !defined(WINDOWS_H)
+	    	    typedef unsigned long DWORD;
+	    	    typedef const wchar_t* LPCWSTR;
+	    	    typedef void* HANDLE;
+	    	    typedef struct HINSTANCE__* HINSTANCE;
+	    	    typedef struct HWND__* HWND;
+	    	    typedef struct HMONITOR__* HMONITOR;
+	    	    typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
+#           endif
 
-#		include <vulkan/vulkan_xlib.h>
+#	    	include <vulkan/vulkan_win32.h>
 
-#		ifdef VK_ENABLE_BETA_EXTENSIONS
-#			include <vulkan/vulkan_beta.h>
-#		endif
-#	elif defined(VK_USE_PLATFORM_XCB_KHR)
-#		include <vulkan/vk_platform.h>
-#		include <vulkan/vulkan_core.h>
+#	    	ifdef VK_ENABLE_BETA_EXTENSIONS
+#	    		include <vulkan/vulkan_beta.h>
+#	    	endif
+#   	else
+#   		include <vulkan/vulkan.h>
+#   	endif
+#	    if defined(VK_USE_PLATFORM_XLIB_KHR)
+#	    	include <vulkan/vk_platform.h>
+#	    	include <vulkan/vulkan_core.h>
 
-#       if !defined(__XCB_H__)
-#           include <stdint.h>
-            typedef struct xcb_connection_t xcb_connection_t;
-            typedef uint32_t xcb_window_t;
-            typedef uint32_t xcb_visualid_t;
-#       endif
+            // This is not 1:1 what Xlib uses, but it's close enough for most purposes.
+#           if !defined(X_H)
+               // This is an include guard for the XLIB_XRANDR platform.
+#              define VOLK_VULKAN_H_DEFINE_XLIB_STRUCTURES
+#              include <stdint.h>
+               typedef struct Display Display;
+               typedef uint32_t Window;
+               typedef uint32_t VisualID;
+#          endif
 
-#		include <vulkan/vulkan_xcb.h>
+#		    include <vulkan/vulkan_xlib.h>
 
-#		ifdef VK_ENABLE_BETA_EXTENSIONS
-#			include <vulkan/vulkan_beta.h>
-#		endif
-#	elif defined(VK_USE_PLATFORM_DIRECTFB_EXT)
-#		include <vulkan/vk_platform.h>
-#		include <vulkan/vulkan_core.h>
+#	    	ifdef VK_ENABLE_BETA_EXTENSIONS
+#		    	include <vulkan/vulkan_beta.h>
+#	    	endif
+#   	else
+#   		include <vulkan/vulkan.h>
+#   	endif
+#	    if defined(VK_USE_PLATFORM_XCB_KHR)
+#	    	include <vulkan/vk_platform.h>
+#	    	include <vulkan/vulkan_core.h>
 
-        struct IDirectFB;
-        struct IDirectFBSurface;
+#          if !defined(__XCB_H__)
+#              include <stdint.h>
+               typedef struct xcb_connection_t xcb_connection_t;
+               typedef uint32_t xcb_window_t;
+               typedef uint32_t xcb_visualid_t;
+#          endif
 
-#		include <vulkan/vulkan_directfb.h>
+#	    	include <vulkan/vulkan_xcb.h>
 
-#		ifdef VK_ENABLE_BETA_EXTENSIONS
-#			include <vulkan/vulkan_beta.h>
-#		endif
-#	elif defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
-#		include <vulkan/vk_platform.h>
-#		include <vulkan/vulkan_core.h>
+#		    ifdef VK_ENABLE_BETA_EXTENSIONS
+#		    	include <vulkan/vulkan_beta.h>
+#	    	endif
+#   	else
+#   		include <vulkan/vulkan.h>
+#   	endif
+#	    if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
+#		    include <vulkan/vk_platform.h>
+#		    include <vulkan/vulkan_core.h>
 
-#       if !defined(X_H)
-            typedef struct Display Display;
-#       endif
-#       if !defined(_RANDRSTR_H_)
-#           include <stdint.h>
-            typedef uint32_t RROutput;
-#       endif
+            struct IDirectFB;
+            struct IDirectFBSurface;
 
-#		include <vulkan/vulkan_xlib_xrandr.h>
+#		    include <vulkan/vulkan_directfb.h>
 
-#		ifdef VK_ENABLE_BETA_EXTENSIONS
-#			include <vulkan/vulkan_beta.h>
-#		endif
-#	elif defined(VK_USE_PLATFORM_SCREEN_QNX)
-#		include <vulkan/vk_platform.h>
-#		include <vulkan/vulkan_core.h>
+#		    ifdef VK_ENABLE_BETA_EXTENSIONS
+#			    include <vulkan/vulkan_beta.h>
+#		    endif
+#   	else
+#   		include <vulkan/vulkan.h>
+#   	endif
+#   	if defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
+#   		include <vulkan/vk_platform.h>
+#   		include <vulkan/vulkan_core.h>
 
-#       if !defined(X_H)
-            typedef struct Display Display;
-#           include <stdint.h>
-            typedef uint32_t RROutput;
-#       endif
+#          if !defined(X_H) && !defined(VOLK_VULKAN_H_DEFINE_XLIB_STRUCTURES)
+               typedef struct Display Display;
+#          endif
+#          if !defined(_RANDRSTR_H_)
+#              include <stdint.h>
+               typedef uint32_t RROutput;
+#          endif
 
-#		include <vulkan/vulkan_ggp.h>
+#   		include <vulkan/vulkan_xlib_xrandr.h>
 
-#		ifdef VK_ENABLE_BETA_EXTENSIONS
-#			include <vulkan/vulkan_beta.h>
-#		endif
-#	else
-#		include <vulkan/vulkan.h>
-#	endif
+#   		ifdef VK_ENABLE_BETA_EXTENSIONS
+#   			include <vulkan/vulkan_beta.h>
+#   		endif
+#   	else
+#   		include <vulkan/vulkan.h>
+#   	endif
+#   	if defined(VK_USE_PLATFORM_GGP)
+#   		include <vulkan/vk_platform.h>
+#   		include <vulkan/vulkan_core.h>
+
+#          if !defined(X_H)
+#             include <stdint.h>
+              typedef uint32_t GgpStreamDescriptor;
+              typedef uint64_t GgpFrameToken;
+#          endif
+
+#   		include <vulkan/vulkan_ggp.h>
+
+#   		ifdef VK_ENABLE_BETA_EXTENSIONS
+#   			include <vulkan/vulkan_beta.h>
+#   		endif
+#   	else
+#   		include <vulkan/vulkan.h>
+#   	endif
 #endif
 
 /* Disable several extensions on earlier SDKs because later SDKs introduce a backwards incompatible change to function signatures */

--- a/volk.h
+++ b/volk.h
@@ -100,12 +100,12 @@
 #		include <vulkan/vk_platform.h>
 #		include <vulkan/vulkan_core.h>
 
-#if !defined(__XCB_H__)
-#       include <stdint.h>
-        typedef struct xcb_connection_t xcb_connection_t;
-        typedef uint32_t xcb_window_t;
-        typedef uint32_t xcb_visualid_t;
-#endif
+#       if !defined(__XCB_H__)
+#           include <stdint.h>
+            typedef struct xcb_connection_t xcb_connection_t;
+            typedef uint32_t xcb_window_t;
+            typedef uint32_t xcb_visualid_t;
+#       endif
 
 #		include <vulkan/vulkan_xcb.h>
 

--- a/volk.h
+++ b/volk.h
@@ -104,6 +104,7 @@
 #       include <stdint.h>
         typedef struct xcb_connection_t xcb_connection_t;
         typedef uint32_t xcb_window_t;
+        typedef uint32_t xcb_visualid_t;
 #endif
 
 #		include <vulkan/vulkan_xcb.h>

--- a/volk.h
+++ b/volk.h
@@ -22,26 +22,137 @@
 #	define VK_NO_PROTOTYPES
 #endif
 
+
+/* When VK_USE_PLATFORM_XYZ is defined, instead of including vulkan.h directly, we include individual parts of the SDK
+ * This is necessary to avoid including platform-specific headers which may be very heavy -
+ * it takes 200ms to parse windows.h without WIN32_LEAN_AND_MEAN and 100ms to parse with it.
+ * The WSI only needs a few symbols that are straightforward to redefine ourselves.
+ * Currently supported platforms:
+ * VK_USE_PLATFORM_FUCHSIA
+ * VK_USE_PLATFORM_WIN32_KHR
+ * VK_USE_PLATFORM_XLIB_KHR
+ * VK_USE_PLATFORM_XCB_KHR
+ * VK_USE_PLATFORM_DIRECTFB_EXT
+ * VK_USE_PLATFORM_XLIB_XRANDR_EXT
+ * VK_USE_PLATFORM_SCI
+ *
+ * Nothing needs to be done for the following platforms as they don't depends on platform-specific headers:
+ * VK_USE_PLATFORM_METAL_EXT
+ * VK_USE_PLATFORM_MACOS_MVK
+ * VK_USE_PLATFORM_METAL_EXT
+ * VK_USE_PLATFORM_VI_NN
+ * VK_USE_PLATFORM_WAYLAND_KHR
+ * VK_USE_PLATFORM_SCREEN_QNX
+ */
+
 #ifndef VULKAN_H_
 #	ifdef VOLK_VULKAN_H_PATH
 #		include VOLK_VULKAN_H_PATH
-#	elif defined(VK_USE_PLATFORM_WIN32_KHR)
+#	elif defined(VK_USE_PLATFORM_FUCHSIA)
 #		include <vulkan/vk_platform.h>
 #		include <vulkan/vulkan_core.h>
 
-		/* When VK_USE_PLATFORM_WIN32_KHR is defined, instead of including vulkan.h directly, we include individual parts of the SDK
-		 * This is necessary to avoid including <windows.h> which is very heavy - it takes 200ms to parse without WIN32_LEAN_AND_MEAN
-		 * and 100ms to parse with it. vulkan_win32.h only needs a few symbols that are easy to redefine ourselves.
-		 */
-		typedef unsigned long DWORD;
-		typedef const wchar_t* LPCWSTR;
-		typedef void* HANDLE;
-		typedef struct HINSTANCE__* HINSTANCE;
-		typedef struct HWND__* HWND;
-		typedef struct HMONITOR__* HMONITOR;
-		typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
+        // If someone knows what the include guard for <lib/zx/handle.h> is, please add a guard arround this
+#       include <stdint.h>
+        uint32_t zx_handle_t;
+
+#		include <vulkan/vulkan_xcb.h>
+
+#		ifdef VK_ENABLE_BETA_EXTENSIONS
+#			include <vulkan/vulkan_beta.h>
+#		endif
+#	elif defined(VK_USE_PLATFORM_WIN32_KHR)
+#		include <vulkan/vk_platform.h>
+#		include <vulkan/vulkan_core.h>
+#       if !defined(WINDOWS_H)
+		    typedef unsigned long DWORD;
+		    typedef const wchar_t* LPCWSTR;
+		    typedef void* HANDLE;
+		    typedef struct HINSTANCE__* HINSTANCE;
+		    typedef struct HWND__* HWND;
+		    typedef struct HMONITOR__* HMONITOR;
+		    typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
+#       endif
 
 #		include <vulkan/vulkan_win32.h>
+
+#		ifdef VK_ENABLE_BETA_EXTENSIONS
+#			include <vulkan/vulkan_beta.h>
+#		endif
+#	elif defined(VK_USE_PLATFORM_XLIB_KHR)
+#		include <vulkan/vk_platform.h>
+#		include <vulkan/vulkan_core.h>
+
+        // This is not 1:1 what Xlib uses, but it's close enough for most purposes.
+#       if !defined(X_H)
+#           include <stdint.h>
+            typedef struct Display Display;
+            typedef uint32_t Window;
+            typedef uint32_t VisualID;
+#       endif
+
+#		include <vulkan/vulkan_xlib.h>
+
+#		ifdef VK_ENABLE_BETA_EXTENSIONS
+#			include <vulkan/vulkan_beta.h>
+#		endif
+#	elif defined(VK_USE_PLATFORM_XCB_KHR)
+#		include <vulkan/vk_platform.h>
+#		include <vulkan/vulkan_core.h>
+
+#if !defined(__XCB_H__)
+#       include <stdint.h>
+        typedef struct xcb_connection_t xcb_connection_t;
+        typedef uint32_t xcb_window_t;
+#endif
+
+#		include <vulkan/vulkan_xcb.h>
+
+#		ifdef VK_ENABLE_BETA_EXTENSIONS
+#			include <vulkan/vulkan_beta.h>
+#		endif
+#	elif defined(VK_USE_PLATFORM_DIRECTFB_EXT)
+#		include <vulkan/vk_platform.h>
+#		include <vulkan/vulkan_core.h>
+
+        struct IDirectFB;
+        struct IDirectFBSurface;
+
+#		include <vulkan/vulkan_directfb.h>
+
+#		ifdef VK_ENABLE_BETA_EXTENSIONS
+#			include <vulkan/vulkan_beta.h>
+#		endif
+#	elif defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
+#		include <vulkan/vk_platform.h>
+#		include <vulkan/vulkan_core.h>
+
+        // This is not 1:1 what Xlib uses, but it's close enough for most purposes.
+#       if !defined(X_H)
+            typedef struct Display Display;
+#       endif
+#       if !defined(_RANDRSTR_H_)
+#           include <stdint.h>
+            typedef uint32_t RROutput;
+#       endif
+
+#		include <vulkan/vulkan_xlib_xrandr.h>
+
+#		ifdef VK_ENABLE_BETA_EXTENSIONS
+#			include <vulkan/vulkan_beta.h>
+#		endif
+#	elif defined(VK_USE_PLATFORM_SCREEN_QNX)
+#		include <vulkan/vk_platform.h>
+#		include <vulkan/vulkan_core.h>
+
+        // This is not 1:1 what Xlib uses, but it's close enough for most purposes.
+#       if !defined(X_H)
+            typedef struct Display Display;
+#           include <stdint.h>
+            typedef uint32_t RROutput;
+#       endif
+
+#		include <vulkan/vulkan_ggp.h>
 
 #		ifdef VK_ENABLE_BETA_EXTENSIONS
 #			include <vulkan/vulkan_beta.h>

--- a/volk.h
+++ b/volk.h
@@ -45,138 +45,79 @@
  */
 
 #ifndef VULKAN_H_
+#	include <vulkan/vulkan_core.h>
+
 #	ifdef VOLK_VULKAN_H_PATH
 #		include VOLK_VULKAN_H_PATH
-#   else
-#       if defined(VK_USE_PLATFORM_FUCHSIA)
-#		    include <vulkan/vk_platform.h>
-#		    include <vulkan/vulkan_core.h>
+#	else
+#		if defined(VK_USE_PLATFORM_FUCHSIA)
+			// If someone knows what the include guard for <lib/zx/handle.h> is, please add a guard arround this
+			typedef uint32_t zx_handle_t;
 
-            // If someone knows what the include guard for <lib/zx/handle.h> is, please add a guard arround this
-#           include <stdint.h>
-            typedef uint32_t zx_handle_t;
+#			include <vulkan/vulkan_fuchsia.h>
+#		endif
+#		if defined(VK_USE_PLATFORM_WIN32_KHR)
+#			if !defined(WINDOWS_H)
+				typedef unsigned long DWORD;
+				typedef const wchar_t* LPCWSTR;
+				typedef void* HANDLE;
+				typedef struct HINSTANCE__* HINSTANCE;
+				typedef struct HWND__* HWND;
+				typedef struct HMONITOR__* HMONITOR;
+				typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
+#			endif
 
-#		    include <vulkan/vulkan_fuchsia.h>
+#			include <vulkan/vulkan_win32.h>
+#		endif
+#		if defined(VK_USE_PLATFORM_XLIB_KHR)
+			// This is not 1:1 what Xlib uses, but it's close enough for most purposes.
+#			if !defined(X_H)
+				// This is an include guard for the XLIB_XRANDR platform.
+#				define VOLK_VULKAN_H_DEFINE_XLIB_STRUCTURES
+				typedef struct Display Display;
+				typedef uint32_t Window;
+				typedef uint32_t VisualID;
+#			endif
 
-#		    ifdef VK_ENABLE_BETA_EXTENSIONS
-#		    	include <vulkan/vulkan_beta.h>
-#		    endif
-#       endif
-#	    if defined(VK_USE_PLATFORM_WIN32_KHR)
-#	    	include <vulkan/vk_platform.h>
-#	    	include <vulkan/vulkan_core.h>
-#           if !defined(WINDOWS_H)
-	    	    typedef unsigned long DWORD;
-	    	    typedef const wchar_t* LPCWSTR;
-	    	    typedef void* HANDLE;
-	    	    typedef struct HINSTANCE__* HINSTANCE;
-	    	    typedef struct HWND__* HWND;
-	    	    typedef struct HMONITOR__* HMONITOR;
-	    	    typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
-#           endif
+#			include <vulkan/vulkan_xlib.h>
+#		endif
+#		if defined(VK_USE_PLATFORM_XCB_KHR)
+#			if !defined(__XCB_H__)
+				typedef struct xcb_connection_t xcb_connection_t;
+				typedef uint32_t xcb_window_t;
+				typedef uint32_t xcb_visualid_t;
+#			endif
 
-#	    	include <vulkan/vulkan_win32.h>
+#			include <vulkan/vulkan_xcb.h>
+#		endif
+#		if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
+			typedef struct IDirectFB IDirectFB;
+			typedef struct IDirectFBSurface IDirectFBSurface;
 
-#	    	ifdef VK_ENABLE_BETA_EXTENSIONS
-#	    		include <vulkan/vulkan_beta.h>
-#	    	endif
-#   	else
-#   		include <vulkan/vulkan.h>
-#   	endif
-#	    if defined(VK_USE_PLATFORM_XLIB_KHR)
-#	    	include <vulkan/vk_platform.h>
-#	    	include <vulkan/vulkan_core.h>
+#			include <vulkan/vulkan_directfb.h>
+#		endif
+#		if defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
+#			if !defined(X_H) && !defined(VOLK_VULKAN_H_DEFINE_XLIB_STRUCTURES)
+				typedef struct Display Display;
+#			endif
+#			if !defined(_RANDRSTR_H_)
+				typedef uint32_t RROutput;
+#			endif
 
-            // This is not 1:1 what Xlib uses, but it's close enough for most purposes.
-#           if !defined(X_H)
-               // This is an include guard for the XLIB_XRANDR platform.
-#              define VOLK_VULKAN_H_DEFINE_XLIB_STRUCTURES
-#              include <stdint.h>
-               typedef struct Display Display;
-               typedef uint32_t Window;
-               typedef uint32_t VisualID;
-#          endif
+#			include <vulkan/vulkan_xlib_xrandr.h>
+#		endif
+#		if defined(VK_USE_PLATFORM_GGP)
+#			if !defined(X_H)
+				typedef uint32_t GgpStreamDescriptor;
+				typedef uint64_t GgpFrameToken;
+#			endif
 
-#		    include <vulkan/vulkan_xlib.h>
-
-#	    	ifdef VK_ENABLE_BETA_EXTENSIONS
-#		    	include <vulkan/vulkan_beta.h>
-#	    	endif
-#   	else
-#   		include <vulkan/vulkan.h>
-#   	endif
-#	    if defined(VK_USE_PLATFORM_XCB_KHR)
-#	    	include <vulkan/vk_platform.h>
-#	    	include <vulkan/vulkan_core.h>
-
-#          if !defined(__XCB_H__)
-#              include <stdint.h>
-               typedef struct xcb_connection_t xcb_connection_t;
-               typedef uint32_t xcb_window_t;
-               typedef uint32_t xcb_visualid_t;
-#          endif
-
-#	    	include <vulkan/vulkan_xcb.h>
-
-#		    ifdef VK_ENABLE_BETA_EXTENSIONS
-#		    	include <vulkan/vulkan_beta.h>
-#	    	endif
-#   	else
-#   		include <vulkan/vulkan.h>
-#   	endif
-#	    if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
-#		    include <vulkan/vk_platform.h>
-#		    include <vulkan/vulkan_core.h>
-
-            struct IDirectFB;
-            struct IDirectFBSurface;
-
-#		    include <vulkan/vulkan_directfb.h>
-
-#		    ifdef VK_ENABLE_BETA_EXTENSIONS
-#			    include <vulkan/vulkan_beta.h>
-#		    endif
-#   	else
-#   		include <vulkan/vulkan.h>
-#   	endif
-#   	if defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
-#   		include <vulkan/vk_platform.h>
-#   		include <vulkan/vulkan_core.h>
-
-#          if !defined(X_H) && !defined(VOLK_VULKAN_H_DEFINE_XLIB_STRUCTURES)
-               typedef struct Display Display;
-#          endif
-#          if !defined(_RANDRSTR_H_)
-#              include <stdint.h>
-               typedef uint32_t RROutput;
-#          endif
-
-#   		include <vulkan/vulkan_xlib_xrandr.h>
-
-#   		ifdef VK_ENABLE_BETA_EXTENSIONS
-#   			include <vulkan/vulkan_beta.h>
-#   		endif
-#   	else
-#   		include <vulkan/vulkan.h>
-#   	endif
-#   	if defined(VK_USE_PLATFORM_GGP)
-#   		include <vulkan/vk_platform.h>
-#   		include <vulkan/vulkan_core.h>
-
-#          if !defined(X_H)
-#             include <stdint.h>
-              typedef uint32_t GgpStreamDescriptor;
-              typedef uint64_t GgpFrameToken;
-#          endif
-
-#   		include <vulkan/vulkan_ggp.h>
-
-#   		ifdef VK_ENABLE_BETA_EXTENSIONS
-#   			include <vulkan/vulkan_beta.h>
-#   		endif
-#   	else
-#   		include <vulkan/vulkan.h>
-#   	endif
+#			include <vulkan/vulkan_ggp.h>
+#		endif
+#		ifdef VK_ENABLE_BETA_EXTENSIONS
+#			include <vulkan/vulkan_beta.h>
+#		endif
+#	endif
 #endif
 
 /* Disable several extensions on earlier SDKs because later SDKs introduce a backwards incompatible change to function signatures */

--- a/volk.h
+++ b/volk.h
@@ -37,7 +37,6 @@
  * VK_USE_PLATFORM_SCI
  *
  * Nothing needs to be done for the following platforms as they don't depend on platform-specific headers:
- * VK_USE_PLATFORM_METAL_EXT
  * VK_USE_PLATFORM_MACOS_MVK
  * VK_USE_PLATFORM_METAL_EXT
  * VK_USE_PLATFORM_VI_NN

--- a/volk.h
+++ b/volk.h
@@ -36,7 +36,7 @@
  * VK_USE_PLATFORM_XLIB_XRANDR_EXT
  * VK_USE_PLATFORM_SCI
  *
- * Nothing needs to be done for the following platforms as they don't depends on platform-specific headers:
+ * Nothing needs to be done for the following platforms as they don't depend on platform-specific headers:
  * VK_USE_PLATFORM_METAL_EXT
  * VK_USE_PLATFORM_MACOS_MVK
  * VK_USE_PLATFORM_METAL_EXT
@@ -127,7 +127,6 @@
 #		include <vulkan/vk_platform.h>
 #		include <vulkan/vulkan_core.h>
 
-        // This is not 1:1 what Xlib uses, but it's close enough for most purposes.
 #       if !defined(X_H)
             typedef struct Display Display;
 #       endif
@@ -145,7 +144,6 @@
 #		include <vulkan/vk_platform.h>
 #		include <vulkan/vulkan_core.h>
 
-        // This is not 1:1 what Xlib uses, but it's close enough for most purposes.
 #       if !defined(X_H)
             typedef struct Display Display;
 #           include <stdint.h>

--- a/volk.h
+++ b/volk.h
@@ -35,13 +35,13 @@
  * VK_USE_PLATFORM_DIRECTFB_EXT
  * VK_USE_PLATFORM_XLIB_XRANDR_EXT
  * VK_USE_PLATFORM_GGP
+ * VK_USE_PLATFORM_SCREEN_QNX
  *
  * Nothing needs to be done for the following platforms as they don't depend on platform-specific headers:
  * VK_USE_PLATFORM_MACOS_MVK
  * VK_USE_PLATFORM_METAL_EXT
  * VK_USE_PLATFORM_VI_NN
  * VK_USE_PLATFORM_WAYLAND_KHR
- * VK_USE_PLATFORM_SCREEN_QNX
  */
 
 #ifndef VULKAN_H_
@@ -55,6 +55,7 @@
 			typedef uint32_t zx_handle_t;
 
 #			include <vulkan/vulkan_fuchsia.h>
+#           undef VK_USE_PLATFORM_FUCHSIA
 #		endif
 #		if defined(VK_USE_PLATFORM_WIN32_KHR)
 #			if !defined(WINDOWS_H)
@@ -68,6 +69,7 @@
 #			endif
 
 #			include <vulkan/vulkan_win32.h>
+#           undef VK_USE_PLATFORM_WIN32_KHR
 #		endif
 #		if defined(VK_USE_PLATFORM_XLIB_KHR)
 			// This is not 1:1 what Xlib uses, but it's close enough for most purposes.
@@ -80,6 +82,7 @@
 #			endif
 
 #			include <vulkan/vulkan_xlib.h>
+#           undef VK_USE_PLATFORM_XLIB_KHR
 #		endif
 #		if defined(VK_USE_PLATFORM_XCB_KHR)
 #			if !defined(__XCB_H__)
@@ -89,12 +92,14 @@
 #			endif
 
 #			include <vulkan/vulkan_xcb.h>
+#           undef VK_USE_PLATFORM_XCB_KHR
 #		endif
 #		if defined(VK_USE_PLATFORM_DIRECTFB_EXT)
 			typedef struct IDirectFB IDirectFB;
 			typedef struct IDirectFBSurface IDirectFBSurface;
 
 #			include <vulkan/vulkan_directfb.h>
+#           undef VK_USE_PLATFORM_DIRECTFB_EXT
 #		endif
 #		if defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
 #			if !defined(X_H) && !defined(VOLK_VULKAN_H_DEFINE_XLIB_STRUCTURES)
@@ -105,18 +110,20 @@
 #			endif
 
 #			include <vulkan/vulkan_xlib_xrandr.h>
+#           undef VK_USE_PLATFORM_XLIB_XRANDR_EXT
 #		endif
 #		if defined(VK_USE_PLATFORM_GGP)
-#			if !defined(X_H)
-				typedef uint32_t GgpStreamDescriptor;
-				typedef uint64_t GgpFrameToken;
-#			endif
+            typedef uint32_t GgpStreamDescriptor;
+            typedef uint64_t GgpFrameToken;
 
 #			include <vulkan/vulkan_ggp.h>
+#           undef VK_USE_PLATFORM_GGP
 #		endif
-#		ifdef VK_ENABLE_BETA_EXTENSIONS
-#			include <vulkan/vulkan_beta.h>
+#		if defined(VK_USE_PLATFORM_SCREEN_QNX)
+#			include <vulkan/vulkan_screen.h>
+#           undef VK_USE_PLATFORM_SCREEN_QNX
 #		endif
+#		include <vulkan/vulkan.h>
 #	endif
 #endif
 


### PR DESCRIPTION
At the moment volk allows the user to use WSI functions for the Win32 platform without having to include `windows.h`.
This is a very useful feature not only to prevent unwanted definitions and reduce compile time but it also allows the developer to separate code handling windowing from the code that handles rendering.

Unfortunately this is not currently available on any other platform.
I have identified the platforms that could benefit from this feature and added it on my fork.
In addition to that I added guards that prevent redefinition of types in case the user includes the library (not that they must be included before `volk.h` for this to work).

I think this is a good change to take into the master branch.