### PR TITLE
CMake: Improve the include path discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,21 +62,22 @@ endif()
 # Vulkan transitive dependency
 
 if(VOLK_PULL_IN_VULKAN)
-  # If CMake has the FindVulkan module and it works, use it.
-  find_package(Vulkan QUIET)
-
   # Try an explicit CMake variable first, then any Vulkan paths
   # discovered by FindVulkan.cmake, then the $VULKAN_SDK environment
   # variable if nothing else works.
   if(VULKAN_HEADERS_INSTALL_DIR)
     message("volk: using VULKAN_HEADERS_INSTALL_DIR option")
     set(VOLK_INCLUDES "${VULKAN_HEADERS_INSTALL_DIR}/include")
-  elseif(Vulkan_INCLUDE_DIRS)
-    message("volk: using Vulkan_INCLUDE_DIRS from FindVulkan module")
-    set(VOLK_INCLUDES "${Vulkan_INCLUDE_DIRS}")
-  elseif(DEFINED ENV{VULKAN_SDK})
-    message("volk: using VULKAN_SDK environment variable")
-    set(VOLK_INCLUDES "$ENV{VULKAN_SDK}/include")
+  else()
+    # If CMake has the FindVulkan module and it works, use it.
+    find_package(Vulkan QUIET)
+    if(Vulkan_INCLUDE_DIRS)
+      message("volk: using Vulkan_INCLUDE_DIRS from FindVulkan module")
+      set(VOLK_INCLUDES "${Vulkan_INCLUDE_DIRS}")
+    elseif(DEFINED ENV{VULKAN_SDK})
+      message("volk: using VULKAN_SDK environment variable")
+      set(VOLK_INCLUDES "$ENV{VULKAN_SDK}/include")
+    endif()
   endif()
 
   if(VOLK_INCLUDES)


### PR DESCRIPTION
There is no need to discovery the vulkan path with FindVulkan.cmake unless VULKAN_HEADERS_INSTALL_DIR was not set explicitly.