### PR TITLE
Remove dependency on Xlib.h

### DIFF
--- a/volk.h
+++ b/volk.h
@@ -25,31 +25,100 @@
 #ifndef VULKAN_H_
 #	ifdef VOLK_VULKAN_H_PATH
 #		include VOLK_VULKAN_H_PATH
-#	elif defined(VK_USE_PLATFORM_WIN32_KHR)
-#		include <vulkan/vk_platform.h>
-#		include <vulkan/vulkan_core.h>
-
-		/* When VK_USE_PLATFORM_WIN32_KHR is defined, instead of including vulkan.h directly, we include individual parts of the SDK
-		 * This is necessary to avoid including <windows.h> which is very heavy - it takes 200ms to parse without WIN32_LEAN_AND_MEAN
-		 * and 100ms to parse with it. vulkan_win32.h only needs a few symbols that are easy to redefine ourselves.
-		 */
-		typedef unsigned long DWORD;
-		typedef const wchar_t* LPCWSTR;
-		typedef void* HANDLE;
-		typedef struct HINSTANCE__* HINSTANCE;
-		typedef struct HWND__* HWND;
-		typedef struct HMONITOR__* HMONITOR;
-		typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
-
-#		include <vulkan/vulkan_win32.h>
-
-#		ifdef VK_ENABLE_BETA_EXTENSIONS
-#			include <vulkan/vulkan_beta.h>
-#		endif
 #	else
-#		include <vulkan/vulkan.h>
-#	endif
+
+/* Instead of directly including vulkan.h, we include individual parts of the SDK
+ * This is necessary to avoid including platform headers (which vulkan.h does unconditionally)
+ * and replace them with forward declarations, which makes build times faster and avoids macro conflicts.
+ */
+#include <vulkan/vk_platform.h>
+#include <vulkan/vulkan_core.h>
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+#include <vulkan/vulkan_android.h>
 #endif
+
+#ifdef VK_USE_PLATFORM_FUCHSIA
+#include <zircon/types.h>
+#include <vulkan/vulkan_fuchsia.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_IOS_MVK
+#include <vulkan/vulkan_ios.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_MACOS_MVK
+#include <vulkan/vulkan_macos.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_METAL_EXT
+#include <vulkan/vulkan_metal.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_VI_NN
+#include <vulkan/vulkan_vi.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+#include <vulkan/vulkan_wayland.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+typedef unsigned long DWORD;
+typedef const wchar_t* LPCWSTR;
+typedef void* HANDLE;
+typedef struct HINSTANCE__* HINSTANCE;
+typedef struct HWND__* HWND;
+typedef struct HMONITOR__* HMONITOR;
+typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES;
+#include <vulkan/vulkan_win32.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_XCB_KHR
+#include <xcb/xcb.h>
+#include <vulkan/vulkan_xcb.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+typedef struct _XDisplay Display;
+typedef unsigned long Window;
+typedef unsigned long VisualID;
+#include <vulkan/vulkan_xlib.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_DIRECTFB_EXT
+#include <directfb.h>
+#include <vulkan/vulkan_directfb.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
+typedef struct _XDisplay Display;
+typedef unsigned long RROutput;
+#include <vulkan/vulkan_xlib_xrandr.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_GGP
+#include <ggp_c/vulkan_types.h>
+#include <vulkan/vulkan_ggp.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+#include <screen/screen.h>
+#include <vulkan/vulkan_screen.h>
+#endif
+
+#ifdef VK_USE_PLATFORM_SCI
+#include <nvscisync.h>
+#include <nvscibuf.h>
+#include <vulkan/vulkan_sci.h>
+#endif
+
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+#include <vulkan/vulkan_beta.h>
+#endif
+
+#	endif
+#endif /* VULKAN_H_ */
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
When building volk with VK_USE_PLATFORM_XLIB_KHR, volk includes Xlib.h as a byproduct of including vulkan.h.

Xlib.h is not a very nice header: it defines a lot of unprefixed macros that may interfere with other code included after volk.h (e.g. it defines Convex which breaks Jolt Physics headers).

On Windows, we've been using a change that includes vulkan_win32.h manually after redefining the subset of windows.h that it needs. This change attempts to do the same for Xlib.h.

Unfortunately, this requires duplicating pretty much the entire vulkan.h to replace these bits; for Windows, there's only one expected platform that can be active at a given time, but on Linux applications might want up to 4 in rare cases (Xlib, Xlib Randr, Xcb, Directfb). The alternative would be to #undef the relevant platform defines before including vulkan.h, but they need to be redefined after include to not break code that relies on them after including volk.h, so it's not clear that this would be much simpler.

Crucially, we define the necessary types exactly like that's done in Xlib.h unconditionally; this ensures that any type mismatches do not depend on the header inclusion order and are caught early.

Fixes #224 
Closes #195