### PR TITLE
chore: fix indentations

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -83,12 +83,12 @@ VkResult volkInitialize(void)
 		module = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
 	if (!module)
 		module = dlopen("libMoltenVK.dylib", RTLD_NOW | RTLD_LOCAL);
-    // Add support for using Vulkan and MoltenVK in a Framework. App store rules for iOS
-    // strictly enforce no .dylib's. If they aren't found it just falls through
-    if (!module)
-        module = dlopen("vulkan.framework/vulkan", RTLD_NOW | RTLD_LOCAL);
-    if (!module)
-        module = dlopen("MoltenVK.framework/MoltenVK", RTLD_NOW | RTLD_LOCAL);
+	// Add support for using Vulkan and MoltenVK in a Framework. App store rules for iOS
+	// strictly enforce no .dylib's. If they aren't found it just falls through
+	if (!module)
+		module = dlopen("vulkan.framework/vulkan", RTLD_NOW | RTLD_LOCAL);
+	if (!module)
+		module = dlopen("MoltenVK.framework/MoltenVK", RTLD_NOW | RTLD_LOCAL);
 	// modern versions of macOS don't search /usr/local/lib automatically contrary to what man dlopen says
 	// Vulkan SDK uses this as the system-wide installation location, so we're going to fallback to this if all else fails
 	if (!module && getenv("DYLD_FALLBACK_LIBRARY_PATH") == NULL)


### PR DESCRIPTION
Fixes indentations which causes issues if compiling with clang where `misleading-indentation` is an error