### PR TITLE
Option to place all symbols in a namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ The above example use `add_subdirectory` to include volk into CMake's build tree
 
 Volk also supports installation and config-file packages. Installation is disabled by default (so as to not pollute user projects with install rules), and can be enabled by passing `-DVOLK_INSTALL=ON` to CMake. Once installed, do something like `find_package(volk CONFIG REQUIRED)` in your project's CMakeLists.txt. The imported volk targets are called `volk::volk` and `volk::volk_headers`.
 
+## CPP namespace
+
+Use `VOLK_CPP_NAMESPACE` to place all symbols in the given namespace. Define needs to be set before including volk header. This can be used in setups where the vulkan loader symbols are loaded via an library that you don't have full control over. Linking can fail as as the signatures don't match. When `VOLK_CPP_NAMESPACE` isn't defined (default) all symbols will be in the C namespace.
+
+```c
+#define VOLK_CPP_NAMESPACE volk
+#define VOLK_IMPLEMENTATION
+#include "volk.h"
+```
+
 ## License
 
 This library is available to anybody free of charge, under the terms of MIT License (see LICENSE.md).

--- a/volk.c
+++ b/volk.c
@@ -33,6 +33,18 @@ __declspec(dllimport) FARPROC __stdcall GetProcAddress(HMODULE, LPCSTR);
 __declspec(dllimport) int __stdcall FreeLibrary(HMODULE);
 #endif
 
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef __cplusplus
+#    ifdef VOLK_CPP_NAMESPACE
+namespace VOLK_CPP_NAMESPACE {
+#    else
+extern "C" {
+#    endif
+#endif
+
 #if defined(__GNUC__)
 #    define VOLK_DISABLE_GCC_PEDANTIC_WARNINGS \
 		_Pragma("GCC diagnostic push") \

--- a/volk.h
+++ b/volk.h
@@ -32,7 +32,11 @@
 #endif
 
 #ifdef __cplusplus
+#    ifdef VOLK_CPP_NAMESPACE
+namespace VOLK_CPP_NAMESPACE {
+#    else
 extern "C" {
+#    endif
 #endif
 
 struct VolkDeviceTable;
@@ -1515,7 +1519,11 @@ struct VolkDeviceTable
 };
 
 #ifdef __cplusplus
+#    ifdef VOLK_CPP_NAMESPACE
+namespace VOLK_CPP_NAMESPACE {
+#    else
 extern "C" {
+#    endif
 #endif
 
 /* VOLK_GENERATE_PROTOTYPES_H */


### PR DESCRIPTION
This PR adds `VOLK_CPP_NAMESPACE` allowing to place all symbols in its own namespace. In some setups a project can both require vulkan loader symbols and volk symbols. Both do not match and linking can fail.

One of these cases is Blender that uses USD/Hydra storm renderer. In Blender 4.5 (and earlier) both would link to vulkan-1.dll, create their own VkInstance/VkDevice and work along side. In Blender 5.0 volk is used to load the Blender Vulkan symbols, but USD/Hydra storm renderer still links to vulkan-1.dll. During linking this fails as both are in the extern "C" namespace.

By placing symbols generated by volk in its own namespace we can work around the limitation.

Blender PR: https://projects.blender.org/blender/blender/pulls/139630