### PR TITLE
Update volkInitialize to also check the MacOS bundle for libMoltenVK

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -90,7 +90,9 @@ VkResult volkInitialize(void)
 	// note: function pointer is cast through void function pointer to silence cast-function-type warning on gcc8
 	vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)(void(*)(void))GetProcAddress(module, "vkGetInstanceProcAddr");
 #elif defined(__APPLE__)
-	void* module = dlopen("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
+	void* module = dlopen("@executable_path/../Frameworks/libMoltenVK.dylib", RTLD_NOW | RTLD_LOCAL);
+	if (!module)
+		module = dlopen("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
 	if (!module)
 		module = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
 	// modern versions of macOS don't search /usr/local/lib automatically contrary to what man dlopen says


### PR DESCRIPTION
The other paths in this function wont work to find ibMoltenVK.dylib if it is located at `Bundle/Contents/Frameworks/ibMoltenVK.dylib`.

I have manually been adding `@executable_path/../Frameworks/libMoltenVK.dylib` to fix the issue for my app and this should not break any existing usage because it will do the same thing as before if libMoltenVK is not located at this path.

This change will first check the bundle and then check the old paths.

(SDL now also does this [https://github.com/libsdl-org/SDL/issues/14313]( https://github.com/libsdl-org/SDL/issues/14313))