### PR TITLE
Revert "Update volkInitialize to also check the MacOS bundle for libMoltenVK"

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -91,9 +91,7 @@ VkResult volkInitialize(void)
 	// note: function pointer is cast through void function pointer to silence cast-function-type warning on gcc8
 	vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)(void(*)(void))GetProcAddress(module, "vkGetInstanceProcAddr");
 #elif defined(__APPLE__)
-	void* module = dlopen("@executable_path/../Frameworks/libMoltenVK.dylib", RTLD_NOW | RTLD_LOCAL);
-	if (!module)
-		module = dlopen("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
+	void* module = dlopen("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
 	if (!module)
 		module = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
 	// modern versions of macOS don't search /usr/local/lib automatically contrary to what man dlopen says


### PR DESCRIPTION
Reverts zeux/volk#262

Reason: this may regress some use cases that rely on Vulkan loader, see https://github.com/zeux/volk/issues/267