### PR TITLE
Add `RTLD_DEEPBIND` flag to dlopen on linux.

### DIFF
--- a/volk.c
+++ b/volk.c
@@ -111,9 +111,9 @@ VkResult volkInitialize(void)
 
 	vkGetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)dlsym(module, "vkGetInstanceProcAddr");
 #else
-	void* module = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL);
+	void* module = dlopen("libvulkan.so.1", RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
 	if (!module)
-		module = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
+		module = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
 	if (!module)
 		return VK_ERROR_INITIALIZATION_FAILED;
 	VOLK_DISABLE_GCC_PEDANTIC_WARNINGS


### PR DESCRIPTION
When loading volk as a shared library, `RTLD_DEEPBIND` with `VOLK_DEFAULT_VISIBILITY` instructs dlopen to look into the library symbols _before_ the global symbols, avoiding conflicts with already loaded libraries. As per [comment on #51](https://github.com/zeux/volk/issues/51#issuecomment-2006275778). 

Should have opened a PR back then, sorry! As far as I know this should be the proper solution to the problem and make volk cleanly usable as a shared library.